### PR TITLE
Replace revisioned sourcemap filename in css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,7 +182,7 @@ gulp.task('sass', () => {
         sassBundle = sassBundle
             .pipe(sourcemaps.init())
             .pipe(sass().on('error', sass.logError))
-            .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: '../../app/sass' }));
+            .pipe(sourcemaps.write('.', { sourceRoot: '../../app/sass' }));
     } else {
         sassBundle = sassBundle.pipe(sass().on('error', sass.logError))
             .pipe(minifycss());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,8 @@ gulp.task('build:app', () => {
     });
 
     appBundler = appBundler
-        .transform('babelify', { presets: ['es2015', 'react'], sourceMap: true, sourceMapRelative: process.cwd()})
+        .transform('babelify', { presets: ['es2015', 'react'] })
+        .transform('business-leagueify')
         .bundle()
         .on('error', handleError)
         .pipe(source('app-bundle.js'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,8 +164,12 @@ gulp.task('revision', () => {
 });
 
 gulp.task('rev-replace', ['revision'], () => {
-    let manifest = gulp.src(`${PATHS.distFolder}/rev-manifest.json`),
-        replaceTargets = [`${PATHS.distFolder}/index.html`, `${PATHS.tempFolder}/service-worker.js`];
+    let manifestFile = require(`./${PATHS.distFolder}/rev-manifest.json`),
+        manifest = gulp.src(`${PATHS.distFolder}/rev-manifest.json`),
+        replaceTargets = [
+            `${PATHS.distFolder}/index.html`,
+            `${PATHS.distFolder}/${manifestFile['business-league.css']}`,
+            `${PATHS.tempFolder}/service-worker.js`];
 
     return gulp.src(replaceTargets)
         .pipe(revReplace({ manifest: manifest }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,7 +182,7 @@ gulp.task('sass', () => {
         sassBundle = sassBundle
             .pipe(sourcemaps.init())
             .pipe(sass().on('error', sass.logError))
-            .pipe(sourcemaps.write('.'));
+            .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: '../../app/sass' }));
     } else {
         sassBundle = sassBundle.pipe(sass().on('error', sass.logError))
             .pipe(minifycss());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,9 +70,7 @@ gulp.task('build:app', () => {
 
     if (ENVIRONMENT.isDev) {
         appBundler = appBundler
-            .pipe(buffer())
-            .pipe(sourcemaps.init({ loadMaps: true }))
-            .pipe(sourcemaps.write('./'));
+            .pipe(buffer());
     } else {
         appBundler = appBundler
             .pipe(buffer())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,7 @@ gulp.task('build:app', () => {
     });
 
     appBundler = appBundler
-        .transform('babelify', { presets: ['es2015', 'react'] })
+        .transform('babelify', { presets: ['es2015', 'react'], sourceMap: true, sourceMapRelative: process.cwd()})
         .bundle()
         .on('error', handleError)
         .pipe(source('app-bundle.js'));

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babelify": "^7.3.0",
     "browser-sync": "^2.18.2",
     "browserify": "^13.1.1",
+    "business-leagueify": "0.0.4",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-clean-css": "^2.2.0",


### PR DESCRIPTION
Investigated the issue with the JS file sourcemaps:
Seems like a problem with browserify not handling the relative/absolute path well.
Tried just about everything, but had no luck yet:
https://github.com/babel/babelify/issues/19
https://github.com/substack/node-browserify/issues/663
https://github.com/thlorenz/mold-source-map/blob/master/examples/browserify-sources.js
https://www.npmjs.com/package/source-map-path-normalizify

Will look into it further